### PR TITLE
Chore: update Jedis to v7.1 and refresh command spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       run: lein deps
 
     - name: Prepeare command config
-      run: 	lein run -m omega-red.gen-cmd-config
+      run: lein run -m omega-red.gen-cmd-config
 
     - name: Run omega-red tests for ${{ matrix.version }}
       id: tests

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/omega-red "2.5.0"
+(defproject org.clojars.lukaszkorecki/omega-red "2.5.1-SNAPSHOT"
   :description "Redis client for Cloure, based on Jedis, with optional Component support"
   :url "https://github.com/nomnom-insights/nomnom.omega-red"
   :license {:name "MIT License"
@@ -10,9 +10,9 @@
                                    :username :env/clojars_username
                                    :password :env/clojars_password}}
 
-  :dependencies [[org.clojure/clojure "1.12.0"]
-                 [com.stuartsierra/component "1.1.0"]
-                 [redis.clients/jedis "6.0.0"]
+  :dependencies [[org.clojure/clojure "1.12.3"]
+                 [com.stuartsierra/component "1.2.0"]
+                 [redis.clients/jedis "7.1.0"]
                  ;; for (de)serializing Clojure data transparently
                  [com.cognitect/transit-clj "1.0.333"]]
 
@@ -23,8 +23,8 @@
 
   :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "2.0.17"]
                                   [org.clojure/tools.logging "1.3.0"]
-                                  [ch.qos.logback/logback-classic "1.5.18"]
-                                  [cheshire "6.0.0"]
+                                  [ch.qos.logback/logback-classic "1.5.21"]
+                                  [cheshire "6.1.0"]
                                   [lambdaisland/kaocha "1.91.1392"]]
                    :extra-paths ["dev-resources" "script"]}}
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/omega-red "2.5.1-SNAPSHOT"
+(defproject org.clojars.lukaszkorecki/omega-red "2.6.0-SNAPSHOT"
   :description "Redis client for Cloure, based on Jedis, with optional Component support"
   :url "https://github.com/nomnom-insights/nomnom.omega-red"
   :license {:name "MIT License"

--- a/resources/redis-commands.edn
+++ b/resources/redis-commands.edn
@@ -31,6 +31,21 @@
           :has-block-key-args? false,
           :num-args 2,
           :tokens []},
+ :hexpireat {:has-variadic-key-args? false,
+             :arguments ("key"
+                         "unix-time-seconds"
+                         "condition"
+                         "numfields"
+                         "field"),
+             :has-only-one-key-arg? true,
+             :command :hexpireat,
+             :process-keys? true,
+             :is-key-first-arg? true,
+             :variadic? true,
+             :process-tokens? true,
+             :has-block-key-args? false,
+             :num-args 5,
+             :tokens ["NX" "XX" "GT" "LT"]},
  :del {:has-variadic-key-args? true,
        :arguments ("key"),
        :has-only-one-key-arg? false,
@@ -69,7 +84,7 @@
                              "group"
                              "id-selector"
                              "mkstream"
-                             "entries-read"),
+                             "entriesread"),
                  :has-only-one-key-arg? true,
                  :command :xgroup.create,
                  :process-keys? true,
@@ -272,6 +287,17 @@
        :has-block-key-args? false,
        :num-args 2,
        :tokens []},
+ :hpexpiretime {:has-variadic-key-args? false,
+                :arguments ("key" "numfields" "field"),
+                :has-only-one-key-arg? true,
+                :command :hpexpiretime,
+                :process-keys? true,
+                :is-key-first-arg? true,
+                :variadic? true,
+                :process-tokens? false,
+                :has-block-key-args? false,
+                :num-args 4,
+                :tokens []},
  :ltrim {:has-variadic-key-args? false,
          :arguments ("key" "start" "stop"),
          :has-only-one-key-arg? true,
@@ -580,6 +606,17 @@
         :has-block-key-args? false,
         :num-args 2,
         :tokens []},
+ :hexpiretime {:has-variadic-key-args? false,
+               :arguments ("key" "numfields" "field"),
+               :has-only-one-key-arg? true,
+               :command :hexpiretime,
+               :process-keys? true,
+               :is-key-first-arg? true,
+               :variadic? true,
+               :process-tokens? false,
+               :has-block-key-args? false,
+               :num-args 4,
+               :tokens []},
  :zincrby {:has-variadic-key-args? false,
            :arguments ("key" "increment" "member"),
            :has-only-one-key-arg? true,
@@ -751,6 +788,17 @@
                :has-block-key-args? false,
                :num-args 4,
                :tokens ["LIMIT"]},
+ :hpttl {:has-variadic-key-args? false,
+         :arguments ("key" "numfields" "field"),
+         :has-only-one-key-arg? true,
+         :command :hpttl,
+         :process-keys? true,
+         :is-key-first-arg? true,
+         :variadic? true,
+         :process-tokens? false,
+         :has-block-key-args? false,
+         :num-args 4,
+         :tokens []},
  :geohash {:has-variadic-key-args? false,
            :arguments ("key" "member"),
            :has-only-one-key-arg? true,
@@ -876,7 +924,7 @@
            :num-args 3,
            :tokens []},
  :hscan {:has-variadic-key-args? false,
-         :arguments ("key" "cursor" "pattern" "count"),
+         :arguments ("key" "cursor" "pattern" "count" "novalues"),
          :has-only-one-key-arg? true,
          :command :hscan,
          :process-keys? true,
@@ -885,7 +933,7 @@
          :process-tokens? true,
          :has-block-key-args? false,
          :num-args 3,
-         :tokens ["MATCH" "COUNT"]},
+         :tokens ["MATCH" "COUNT" "NOVALUES"]},
  :lolwut {:has-variadic-key-args? false,
           :arguments ("version"),
           :has-only-one-key-arg? false,
@@ -993,7 +1041,8 @@
                         "LADDR"
                         "YES"
                         "NO"
-                        "SKIPME"]},
+                        "SKIPME"
+                        "MAXAGE"]},
  :sintercard {:has-variadic-key-args? false,
               :arguments ("numkeys" "key" "limit"),
               :has-only-one-key-arg? false,
@@ -1005,6 +1054,17 @@
               :has-block-key-args? false,
               :num-args 3,
               :tokens ["LIMIT"]},
+ :hpersist {:has-variadic-key-args? false,
+            :arguments ("key" "numfields" "field"),
+            :has-only-one-key-arg? true,
+            :command :hpersist,
+            :process-keys? true,
+            :is-key-first-arg? true,
+            :variadic? true,
+            :process-tokens? false,
+            :has-block-key-args? false,
+            :num-args 4,
+            :tokens []},
  :hget {:has-variadic-key-args? false,
         :arguments ("key" "field"),
         :has-only-one-key-arg? true,
@@ -1038,6 +1098,21 @@
          :has-block-key-args? false,
          :num-args 1,
          :tokens ["AUTH" "SETNAME"]},
+ :hexpire {:has-variadic-key-args? false,
+           :arguments ("key"
+                       "seconds"
+                       "condition"
+                       "numfields"
+                       "field"),
+           :has-only-one-key-arg? true,
+           :command :hexpire,
+           :process-keys? true,
+           :is-key-first-arg? true,
+           :variadic? true,
+           :process-tokens? true,
+           :has-block-key-args? false,
+           :num-args 5,
+           :tokens ["NX" "XX" "GT" "LT"]},
  :move {:has-variadic-key-args? false,
         :arguments ("key" "db"),
         :has-only-one-key-arg? true,
@@ -1060,6 +1135,21 @@
                    :has-block-key-args? false,
                    :num-args 3,
                    :tokens ["ON" "OFF"]},
+ :hpexpire {:has-variadic-key-args? false,
+            :arguments ("key"
+                        "milliseconds"
+                        "condition"
+                        "numfields"
+                        "field"),
+            :has-only-one-key-arg? true,
+            :command :hpexpire,
+            :process-keys? true,
+            :is-key-first-arg? true,
+            :variadic? true,
+            :process-tokens? true,
+            :has-block-key-args? false,
+            :num-args 5,
+            :tokens ["NX" "XX" "GT" "LT"]},
  :hexists {:has-variadic-key-args? false,
            :arguments ("key" "field"),
            :has-only-one-key-arg? true,
@@ -1334,6 +1424,21 @@
           :has-block-key-args? false,
           :num-args 1,
           :tokens ["SCHEDULE"]},
+ :hpexpireat {:has-variadic-key-args? false,
+              :arguments ("key"
+                          "unix-time-milliseconds"
+                          "condition"
+                          "numfields"
+                          "field"),
+              :has-only-one-key-arg? true,
+              :command :hpexpireat,
+              :process-keys? true,
+              :is-key-first-arg? true,
+              :variadic? true,
+              :process-tokens? true,
+              :has-block-key-args? false,
+              :num-args 5,
+              :tokens ["NX" "XX" "GT" "LT"]},
  :replicaof {:has-variadic-key-args? false,
              :arguments ("args"),
              :has-only-one-key-arg? false,
@@ -2001,6 +2106,17 @@
          :has-block-key-args? false,
          :num-args 4,
          :tokens []},
+ :httl {:has-variadic-key-args? false,
+        :arguments ("key" "numfields" "field"),
+        :has-only-one-key-arg? true,
+        :command :httl,
+        :process-keys? true,
+        :is-key-first-arg? true,
+        :variadic? true,
+        :process-tokens? false,
+        :has-block-key-args? false,
+        :num-args 4,
+        :tokens []},
  :function.flush {:has-variadic-key-args? false,
                   :arguments ("flush-type"),
                   :has-only-one-key-arg? false,
@@ -2056,6 +2172,38 @@
                          :has-block-key-args? false,
                          :num-args 5,
                          :tokens []},
+ :hsetf {:has-variadic-key-args? false,
+         :arguments ("key"
+                     "create key option"
+                     "create option"
+                     "return option"
+                     "condition"
+                     "expiration"
+                     "fvs"
+                     "count"
+                     "data"),
+         :has-only-one-key-arg? true,
+         :command :hsetf,
+         :process-keys? true,
+         :is-key-first-arg? true,
+         :variadic? true,
+         :process-tokens? true,
+         :has-block-key-args? false,
+         :num-args 6,
+         :tokens ["DC"
+                  "DCF"
+                  "DOF"
+                  "GETNEW"
+                  "GETOLD"
+                  "NX"
+                  "XX"
+                  "GT"
+                  "LT"
+                  "EX"
+                  "PX"
+                  "EXAT"
+                  "PXAT"
+                  "KEEPTTL"]},
  :zinter {:has-variadic-key-args? false,
           :arguments ("numkeys"
                       "key"
@@ -2310,6 +2458,30 @@
           :has-block-key-args? false,
           :num-args 4,
           :tokens ["BYSCORE" "BYLEX" "REV" "LIMIT" "WITHSCORES"]},
+ :hgetf {:has-variadic-key-args? false,
+         :arguments ("key"
+                     "condition"
+                     "expiration"
+                     "fields"
+                     "count"
+                     "field"),
+         :has-only-one-key-arg? true,
+         :command :hgetf,
+         :process-keys? true,
+         :is-key-first-arg? true,
+         :variadic? true,
+         :process-tokens? true,
+         :has-block-key-args? false,
+         :num-args 5,
+         :tokens ["NX"
+                  "XX"
+                  "GT"
+                  "LT"
+                  "EX"
+                  "PX"
+                  "EXAT"
+                  "PXAT"
+                  "PERSIST"]},
  :zremrangebyscore {:has-variadic-key-args? false,
                     :arguments ("key" "min" "max"),
                     :has-only-one-key-arg? true,

--- a/src/omega_red/lock.clj
+++ b/src/omega_red/lock.clj
@@ -42,28 +42,25 @@
 (defn try-acquire-with-timeout*
   "Try acquiring a lock, with a timeout options"
   [conn {:keys [lock-key lock-id expiry-ms acquire-timeout-ms acquire-resolution-ms]}]
-
   {:pre [(not-blank? lock-key)
          (not-blank? lock-id)
-
          (pos? expiry-ms)
          (pos? acquire-timeout-ms)
          (pos? acquire-resolution-ms)]}
-  (let [prefixed-lock-key (redis/key (:key-prefix conn) lock-key)]
-    (loop [timeout acquire-timeout-ms]
-      (let [result (redis/execute conn [:eval lock-script 1 prefixed-lock-key lock-id (str expiry-ms)])
-            acquired? (and (number? result) (pos? result))]
-        (if acquired?
-          true
+  (loop [timeout acquire-timeout-ms]
+    (if (try-acquire* conn {:lock-key lock-key
+                            :lock-id lock-id
+                            :expiry-ms expiry-ms})
+      true
           ;; try acquiring
-          (if (pos? (- timeout acquire-resolution-ms))
-            (do
-              (try
-                (Thread/sleep ^long acquire-resolution-ms)
-                (catch InterruptedException _e
-                  ::no-op))
-              (recur (- timeout acquire-resolution-ms)))
-            false))))))
+      (if (pos? (- timeout acquire-resolution-ms))
+        (do
+          (try
+            (Thread/sleep ^long acquire-resolution-ms)
+            (catch InterruptedException _e
+              ::no-op))
+          (recur (- timeout acquire-resolution-ms)))
+        false))))
 
 (defn release*
   [conn {:keys [lock-key lock-id expiry-ms]}]
@@ -96,6 +93,7 @@
 (defrecord RedisLock
   [conn ;; injected
    lock-key ;; shared key to 'lock' on
+   release-on-stop? ;; whether to release the lock on component stop
    expiry-ms ;; how long to keep the lock
    acquire-timeout-ms ;; how long to wait for the lock
    acquire-resolution-ms ;; how often to check for the lock
@@ -112,7 +110,8 @@
              :lock-id (str lock-key "-" (random-uuid)))))
 
   (stop [this]
-    (release this)
+    (when (and release-on-stop? (:lock-id this))
+      (release this))
     (assoc this :lock-key nil :lock-id nil))
 
   RedLock
@@ -157,8 +156,9 @@
   default-acquire-resolution-ms
   100) ;; 100ms
 
-(defn create [{:keys [lock-key lock-id expiry-ms acquire-timeout-ms acquire-resolution-ms]
-               :or {expiry-ms default-expiry-ms
+(defn create [{:keys [lock-key lock-id expiry-ms acquire-timeout-ms acquire-resolution-ms release-on-stop?]
+               :or {release-on-stop? true
+                    expiry-ms default-expiry-ms
                     acquire-timeout-ms default-acquire-timeout-ms
                     acquire-resolution-ms default-acquire-resolution-ms}}]
   {:pre [(not (str/blank? lock-key))
@@ -167,6 +167,7 @@
          (> acquire-timeout-ms acquire-resolution-ms 0)]}
   (map->RedisLock {:lock-key lock-key
                    :lock-id lock-id
+                   :release-on-stop? release-on-stop?
                    :expiry-ms expiry-ms
                    :acquire-timeout-ms acquire-timeout-ms
                    :acquire-resolution-ms acquire-resolution-ms}))


### PR DESCRIPTION
Follow up to #10 

- updates all dependencies, including Jedis v7.1 which adds new commands, removes deprecated features (which we don't care about)
- refreshes command specs to add support for new Redis commands

Released as `v2.6.0-SNAPSHOT`